### PR TITLE
サイレントリフレッシュ機能

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,18 +9,23 @@ import { queryClient } from 'queryClient';
 import { theme } from 'theme';
 import { UserAuthProvider } from 'provider/UserAuthProvider';
 import { Router } from 'router/Router';
+import { injectStore } from 'feature/api';
 
-const App: VFC = () => (
-  <Provider store={store}>
-    <QueryClientProvider client={queryClient}>
-      <ChakraProvider theme={theme}>
-        <UserAuthProvider>
-          <Router />
-        </UserAuthProvider>
-      </ChakraProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
-  </Provider>
-);
+const App: VFC = () => {
+  injectStore(store);
+
+  return (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <ChakraProvider theme={theme}>
+          <UserAuthProvider>
+            <Router />
+          </UserAuthProvider>
+        </ChakraProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </Provider>
+  );
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,16 @@ import { ChakraProvider } from '@chakra-ui/react';
 import { store } from 'store';
 import { queryClient } from 'queryClient';
 import { theme } from 'theme';
+import { UserAuthProvider } from 'provider/UserAuthProvider';
 import { Router } from 'router/Router';
 
 const App: VFC = () => (
   <Provider store={store}>
     <QueryClientProvider client={queryClient}>
       <ChakraProvider theme={theme}>
-        <Router />
+        <UserAuthProvider>
+          <Router />
+        </UserAuthProvider>
       </ChakraProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/src/containers/organisms/Header.tsx
+++ b/src/containers/organisms/Header.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { Header } from 'components/organisms/Header';
 import { useAppSelector, useAppDispatch, setUserAuth } from 'store';
 import { logout } from 'feature/api/users/logout';
-import { isErrMessages } from 'feature/api';
+import { ApiError } from 'feature/api';
 import { useQueryClient } from 'react-query';
 
 export const EnhancedHeader: VFC = () => {
@@ -24,8 +24,6 @@ export const EnhancedHeader: VFC = () => {
   const logoutOnClick = async () => {
     setIsLoading(() => true);
     try {
-      // 401エラーはrefreshTokenも削除され、後続処理が可能なため、
-      // エラー表示で処理をとめない（よってisSuccessフラグで処理判定しない）
       await logout();
       navigate('/');
       dispatch(setUserAuth(null));
@@ -33,7 +31,12 @@ export const EnhancedHeader: VFC = () => {
       onModalClose();
     } catch (error) {
       // 401以外のエラーはrefreshTokenが削除せないため、メッセージ表示
-      if (isErrMessages(error)) setApiMessages(error);
+      if (error instanceof ApiError) {
+        setApiMessages(error.displayMessages);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
     } finally {
       setIsLoading(() => false);
     }

--- a/src/containers/pages/Creators.tsx
+++ b/src/containers/pages/Creators.tsx
@@ -1,29 +1,20 @@
-import { useEffect, VFC } from 'react';
+import { VFC } from 'react';
 import { useQuery } from 'react-query';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { Creators } from 'components/pages/Creators';
-import { useAppSelector } from 'store';
 import { getCreators } from 'feature/api/creator/getCreators';
 import { Creator } from 'feature/models/creator';
+import { ApiError } from 'feature/api';
+import { useLogout } from 'feature/hooks/useLogout';
 
 export const EnhancedCreators: VFC = () => {
-  const userAuth = useAppSelector((state) => state.userAuth);
-  const accessToken = userAuth?.accessToken;
-  const email = userAuth?.loginUser?.email;
-
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!accessToken) navigate('/users/sessions/login');
-  }, [accessToken, navigate]);
-
   const { data, error, isLoading, isFetching } = useQuery<
     { creators?: Creator[] },
-    string[]
-  >([email, 'creators'], () => getCreators({ accessToken }), {
-    enabled: !!accessToken,
-  });
+    ApiError
+  >(['creators'], getCreators);
+
+  useLogout(error);
 
   const creatorEntryLinkProps = {
     as: Link,
@@ -32,7 +23,7 @@ export const EnhancedCreators: VFC = () => {
 
   return (
     <Creators
-      apiMessages={error}
+      apiMessages={error?.action === 'none' ? error.displayMessages : undefined}
       isLoading={isLoading}
       isFetching={isFetching}
       creators={data?.creators}

--- a/src/containers/pages/Login.tsx
+++ b/src/containers/pages/Login.tsx
@@ -4,21 +4,27 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { Login } from 'components/pages/Login';
 import { useAppDispatch, setUserAuth, useAppSelector } from 'store';
-import { login, LoginParams } from 'feature/api/users/login';
+import { login } from 'feature/api/users/login';
+import { ApiError } from 'feature/api';
+
+export type FormData = {
+  email: string;
+  password: string;
+};
 
 export const EnhancedLogin: VFC = () => {
   const [apiMessages, setApiMessages] = useState<string[]>();
+  const userAuth = useAppSelector((state) => state.userAuth);
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
   const locationState = location.state as { from: Location };
-  const userAuth = useAppSelector((state) => state.userAuth);
   const from = locationState ? locationState.from.pathname : '/users/me/works';
   const {
     register,
     handleSubmit,
     formState: { errors, isValid, isSubmitting },
-  } = useForm<LoginParams>({ criteriaMode: 'all', mode: 'all' });
+  } = useForm<FormData>({ criteriaMode: 'all', mode: 'all' });
 
   useEffect(() => {
     if (userAuth) {
@@ -27,20 +33,23 @@ export const EnhancedLogin: VFC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userAuth]);
 
-  const onSubmit: SubmitHandler<LoginParams> = async (submitData) => {
-    const { userAuth: newUserAuth, errorMessages } = await login(submitData);
-    if (newUserAuth) {
+  const onSubmit: SubmitHandler<FormData> = async (formData) => {
+    try {
+      const { userAuth: newUserAuth } = await login(formData);
       dispatch(setUserAuth(newUserAuth));
       navigate(from, { replace: true });
-    } else if (errorMessages) {
-      setApiMessages(() => errorMessages);
-    } else {
-      setApiMessages(() => ['システムエラー（エラー情報なし）']);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setApiMessages(error.displayMessages);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
     }
   };
 
   const emailProps = {
-    ...register('auth.email', {
+    ...register('email', {
       required: '必須入力です',
       maxLength: { value: 30, message: '30桁以内で入力してください' },
       pattern: {
@@ -49,17 +58,17 @@ export const EnhancedLogin: VFC = () => {
         message: 'メールアドレス形式で入力してください',
       },
     }),
-    isInvalid: !!errors?.auth?.email,
-    errorTypes: errors?.auth?.email?.types,
+    isInvalid: !!errors?.email,
+    errorTypes: errors?.email?.types,
   };
 
   const passwordProps = {
-    ...register('auth.password', {
+    ...register('password', {
       required: '必須入力です',
       maxLength: { value: 30, message: '30桁以内で入力してください' },
     }),
-    isInvalid: !!errors?.auth?.password,
-    errorTypes: errors?.auth?.password?.types,
+    isInvalid: !!errors?.password,
+    errorTypes: errors?.password?.types,
     handleChange: (e: ChangeEvent<HTMLInputElement>) => {
       const { value } = e.target;
       if (value.length > 30) {

--- a/src/feature/api/creator/create.ts
+++ b/src/feature/api/creator/create.ts
@@ -1,19 +1,14 @@
-import ky, { HTTPError } from 'ky';
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { HTTPError } from 'ky';
 import snakecaseKeys from 'snakecase-keys';
 
-import { DEFAULT_API_OPTIONS } from 'feature/api/config';
+import { ApiError, isErrResBody, requireUserAuthApi } from 'feature/api';
+import { InputData } from 'containers/pages/CreatorEntry';
 
-type ArgData = {
-  name: string;
-  dateOfBirth: string;
-  gender: string;
-  relation: string;
-  accessToken: string;
-};
+type ArgData = InputData;
 
 type RtnData = {
-  isSuccess?: boolean;
-  errorMessages?: string[];
+  isSuccess: boolean;
 };
 
 type OkResBody = {
@@ -33,63 +28,45 @@ const isOkResBody = (arg: unknown): arg is OkResBody => {
   );
 };
 
-type ErrResBody = {
-  success: boolean;
-  code: string;
-  messages: string[];
-};
-
-const isErrResBody = (arg: unknown): arg is ErrResBody => {
-  const b = arg as ErrResBody;
-
-  return (
-    typeof b?.success === 'boolean' &&
-    b?.success === false &&
-    typeof b?.code === 'string'
-  );
-};
-
 export const createCreator = async (argData: ArgData): Promise<RtnData> => {
-  const reqHeaders = {
-    Authorization: `Bearer ${argData.accessToken}`,
-  };
-  const reqBody = {
-    creator: {
-      name: argData.name,
-      // dateOfBirth: argData.dateOfBirth.toISOString().split('T')[0], //Date型で扱う際は変換要
-      dateOfBirth: argData.dateOfBirth,
-      genderId: argData.gender,
-      relationId: argData.relation,
-    },
-  };
-  const mergedOptions = {
-    ...DEFAULT_API_OPTIONS,
-    ...{ headers: reqHeaders },
-    ...{ json: snakecaseKeys(reqBody, { deep: true }) },
-  };
-  let isSuccess;
-  let errorMessages;
+  const snkcsArgData = snakecaseKeys(argData);
+  const reqData = new FormData();
+  Object.keys(snkcsArgData).forEach((key) => {
+    reqData.append(
+      `creator[${key}]`,
+      snkcsArgData[key as keyof typeof snkcsArgData],
+    );
+  });
+
+  let isSuccess = false;
   try {
-    const response = await ky.post('users/me/creators', mergedOptions);
+    const response = await requireUserAuthApi.post('users/me/creators', {
+      body: reqData,
+    });
     const body = (await response.json()) as unknown;
     if (!isOkResBody(body)) {
-      throw Error('CreatorCreateApiResponseBody unexpected');
+      throw new ApiError(
+        'システムエラー：サーバー・クライアント間矛盾',
+        'refresh:ResBodyUnexpected',
+      );
     }
     isSuccess = body.success;
   } catch (error) {
-    if (error instanceof HTTPError) {
+    if (error instanceof ApiError) {
+      throw error;
+    } else if (error instanceof HTTPError) {
       const errorBody = (await error.response.json()) as unknown;
       if (isErrResBody(errorBody)) {
-        errorMessages = errorBody.messages;
+        throw new ApiError(errorBody.messages, errorBody.code);
       } else {
-        errorMessages = [
+        throw new ApiError(
           `${error.response.status}: ${error.response.statusText}`,
-        ];
+        );
       }
     } else {
-      errorMessages = ['サーバーに接続、または使用できません'];
+      throw new ApiError('サーバーに接続できません', 'other');
     }
   }
 
-  return { isSuccess, errorMessages };
+  return { isSuccess };
 };

--- a/src/feature/api/index.ts
+++ b/src/feature/api/index.ts
@@ -1,7 +1,132 @@
-type ErrMessages = string[];
+import ky, { NormalizedOptions } from 'ky';
+import camelcaseKeys from 'camelcase-keys';
 
-export const isErrMessages = (arg: unknown): arg is ErrMessages => {
-  const b = arg as ErrMessages;
+import { config } from 'config';
+import { setUserAuth, StoreType } from 'store';
+import { refresh } from 'feature/api/users/refresh';
 
-  return Array.isArray(b) && b.every((i) => typeof i === 'string');
+type ApiErrorAction = 'none' | 'logout';
+
+export class ApiError extends Error {
+  displayMessages: string[];
+  action: ApiErrorAction;
+  constructor(
+    displayMessages: string | string[],
+    message = typeof displayMessages === 'string'
+      ? displayMessages
+      : `${displayMessages[0]}_etc`,
+    action: ApiErrorAction = 'none',
+  ) {
+    super(message);
+    this.name = 'ApiError';
+    this.displayMessages =
+      typeof displayMessages === 'string' ? [displayMessages] : displayMessages;
+    this.action = action;
+  }
+}
+
+let store: StoreType;
+
+export const injectStore = (_store: StoreType) => {
+  store = _store;
 };
+
+export const defApi = ky.create({
+  prefixUrl: config.API_URL + config.API_VERSION,
+  timeout: 8000,
+  retry: 1,
+  hooks: {
+    afterResponse: [
+      async (
+        _request: Request,
+        _options: NormalizedOptions,
+        response: Response,
+      ): Promise<Response> => {
+        const body = new Blob(
+          [
+            JSON.stringify(
+              camelcaseKeys(await response.json(), { deep: true }),
+              null,
+              2,
+            ),
+          ],
+          { type: 'application/json' },
+        );
+        const { headers, status, statusText } = response;
+        const init = { headers, status, statusText };
+
+        return new Response(body, init);
+      },
+    ],
+  },
+});
+
+type ErrResBody = {
+  success: boolean;
+  code: string;
+  messages: string[];
+};
+
+export const isErrResBody = (arg: unknown): arg is ErrResBody => {
+  const b = arg as ErrResBody;
+
+  return (
+    typeof b?.success === 'boolean' &&
+    b?.success === false &&
+    typeof b?.code === 'string' &&
+    Array.isArray(b?.messages) &&
+    b?.messages.every((i) => typeof i === 'string')
+  );
+};
+
+export const requireUserAuthApi = defApi.extend({
+  hooks: {
+    beforeRequest: [
+      async (request) => {
+        const { userAuth } = store.getState();
+        if (userAuth) {
+          const { expires } = userAuth.accessToken;
+          const now = new Date().getTime();
+          if (now > expires) {
+            const { userAuth: newUserAuth } = await refresh();
+            if (newUserAuth) {
+              store.dispatch(setUserAuth(newUserAuth));
+              request.headers.set(
+                'Authorization',
+                `Bearer ${newUserAuth.accessToken.token}`,
+              );
+            }
+          } else {
+            request.headers.set(
+              'Authorization',
+              `Bearer ${userAuth.accessToken.token}`,
+            );
+          }
+        }
+      },
+    ],
+    afterResponse: [
+      async (request, _error, response) => {
+        const { userAuth } = store.getState();
+        if (userAuth) {
+          const responseClone = response.clone();
+          const body = (await responseClone.json()) as unknown;
+          if (isErrResBody(body) && body.code === 'access_token_expired') {
+            const { userAuth: newUserAuth } = await refresh();
+            if (newUserAuth) {
+              store.dispatch(setUserAuth(newUserAuth));
+              request.headers.set(
+                'Authorization',
+                `Bearer ${newUserAuth.accessToken.token}`,
+              );
+
+              return defApi(request);
+            }
+          }
+        }
+
+        return response;
+      },
+    ],
+  },
+});

--- a/src/feature/api/select/index.ts
+++ b/src/feature/api/select/index.ts
@@ -1,13 +1,13 @@
-import ky, { HTTPError } from 'ky';
+import { HTTPError } from 'ky';
 
-import { DEFAULT_API_OPTIONS } from 'feature/api/config';
+import { ApiError, defApi, isErrResBody } from 'feature/api';
 import { CmnSelectProps } from 'components/molecules/CmnSelect';
 
 type ArgData = {
   path: string;
 };
 
-export type SeletcOptions = {
+type RtnData = {
   options?: CmnSelectProps['options'];
 };
 
@@ -41,19 +41,16 @@ const isOkResBody = (arg: unknown): arg is OkResBody => {
   );
 };
 
-export const selectOptions = async (
-  argData: ArgData,
-): Promise<SeletcOptions> => {
-  const mergedOptions = {
-    ...DEFAULT_API_OPTIONS,
-  };
+export const selectOptions = async (argData: ArgData): Promise<RtnData> => {
   let options;
-  let errorMessages;
   try {
-    const response = await ky.get(argData.path, mergedOptions);
+    const response = await defApi.get(argData.path);
     const body = (await response.json()) as unknown;
     if (!isOkResBody(body)) {
-      throw Error('ResBodyUnexpected');
+      throw new ApiError(
+        '選択肢の取得に失敗しました：システムエラー',
+        'refresh:ResBodyUnexpected',
+      );
     }
     options = body.options.map((option) => {
       const id =
@@ -62,19 +59,27 @@ export const selectOptions = async (
       return { id, value: option.value };
     });
   } catch (error) {
-    if (error instanceof HTTPError) {
-      errorMessages = ['選択肢の取得に失敗しました'];
-    } else if (
-      error instanceof Error &&
-      error.message === 'ResBodyUnexpected'
-    ) {
-      errorMessages = ['選択肢の取得に失敗しました：システムエラー'];
+    if (error instanceof ApiError) {
+      throw error;
+    } else if (error instanceof HTTPError) {
+      const errorBody = (await error.response.json()) as unknown;
+      if (isErrResBody(errorBody)) {
+        throw new ApiError('選択肢の取得に失敗しました', errorBody.code);
+      } else {
+        throw new ApiError(
+          '選択肢の取得に失敗しました',
+          `${error.response.status}: ${error.response.statusText}`,
+        );
+      }
     } else {
-      errorMessages = ['選択肢の取得に失敗しました：サーバー接続エラー'];
-
-      throw errorMessages;
+      throw new ApiError(
+        '選択肢の取得に失敗しました：サーバー接続エラー',
+        'other',
+      );
     }
   }
 
   return { options };
 };
+
+export type SeletcOptions = RtnData;

--- a/src/feature/api/users/refresh.ts
+++ b/src/feature/api/users/refresh.ts
@@ -1,0 +1,94 @@
+import ky, { HTTPError } from 'ky';
+
+import { DEFAULT_API_OPTIONS } from 'feature/api/config';
+import { UserAuth } from 'feature/models/user';
+
+type OkResBody = {
+  success: boolean;
+  token: string;
+  expires: number;
+  user: {
+    name: string;
+    email: string;
+    resizeAvatarUrl?: string | null;
+  };
+};
+
+type ErrResBody = {
+  success: boolean;
+  code: string;
+  messages: string[];
+};
+
+type Result = {
+  userAuth: UserAuth;
+};
+
+const isOkResBody = (arg: unknown): arg is OkResBody => {
+  const b = arg as OkResBody;
+
+  return (
+    typeof b?.success === 'boolean' &&
+    b?.success === true &&
+    typeof b?.token === 'string' &&
+    typeof b?.expires === 'number' &&
+    new Date(b?.expires * 1000).toString() !== 'Invalid Date' &&
+    typeof b?.user?.name === 'string' &&
+    typeof b?.user?.email === 'string' &&
+    (typeof b?.user?.resizeAvatarUrl === 'string' ||
+      [null, undefined].includes(b?.user?.resizeAvatarUrl))
+  );
+};
+
+const isErrResBody = (arg: unknown): arg is ErrResBody => {
+  const b = arg as ErrResBody;
+
+  return (
+    typeof b?.success === 'boolean' &&
+    b?.success === false &&
+    typeof b?.code === 'string' &&
+    Array.isArray(b?.messages) &&
+    b?.messages.every((i) => typeof i === 'string')
+  );
+};
+
+export const refresh = async (): Promise<Result> => {
+  const credentials: RequestCredentials = 'include';
+  const mergedOptions = {
+    ...DEFAULT_API_OPTIONS,
+    ...{ credentials }, // Cookie保存
+  };
+  let userAuth: UserAuth = null;
+  let errorMessages;
+  try {
+    const response = await ky.post('users/sessions/refresh', mergedOptions);
+    const body = (await response.json()) as unknown;
+    if (!isOkResBody(body)) {
+      throw Error('ApiResBodyUnexpected');
+    }
+    const loginUser = body.user;
+    const accessToken = {
+      token: body.token,
+      expires: new Date(body.expires * 1000).toISOString(),
+    };
+    userAuth = { accessToken, loginUser };
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      const errorBody = (await error.response.json()) as unknown;
+      if (isErrResBody(errorBody)) {
+        errorMessages = errorBody.messages;
+      } else {
+        errorMessages = [
+          `${error.response.status}: ${error.response.statusText}`,
+        ];
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      errorMessages = ['サーバーに接続、または使用できません'];
+    }
+    throw errorMessages;
+  }
+
+  return { userAuth };
+};

--- a/src/feature/hooks/useLogout.ts
+++ b/src/feature/hooks/useLogout.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useQueryClient } from 'react-query';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useToast } from '@chakra-ui/react';
+
+import { ApiError } from 'feature/api';
+import { setUserAuth, useAppDispatch } from 'store';
+
+export const useLogout = (error: ApiError | null) => {
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (error?.action === 'logout') {
+      dispatch(setUserAuth(null));
+      queryClient.clear();
+      toast({
+        title: error.displayMessages,
+        status: 'error',
+        isClosable: true,
+      });
+      navigate('/users/sessions/login', { state: { from: location } });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error]);
+};

--- a/src/feature/models/user.ts
+++ b/src/feature/models/user.ts
@@ -1,6 +1,6 @@
 export type AccessToken = {
   token: string;
-  expires: string;
+  expires: number;
 };
 
 export type LoginUser = {

--- a/src/feature/models/user.ts
+++ b/src/feature/models/user.ts
@@ -6,7 +6,7 @@ export type AccessToken = {
 export type LoginUser = {
   name: string;
   email: string;
-  resizeAvatarUrl?: string | null;
+  avatarUrl?: string | null;
 };
 
 export type UserAuth = {

--- a/src/provider/UserAuthProvider.tsx
+++ b/src/provider/UserAuthProvider.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState, VFC } from 'react';
 
 import { refresh } from 'feature/api/users/refresh';
 import { useAppDispatch, setUserAuth } from 'store';
-import { isErrMessages } from 'feature/api';
 import { DataLoading } from 'components/atoms/DataLoading';
+// import { ApiError } from 'api';
 
 type Type = {
   children: JSX.Element;
@@ -21,8 +21,7 @@ export const UserAuthProvider: VFC<Type> = ({ children }) => {
           dispatch(setUserAuth(userAuth));
         }
       } catch (error) {
-        // eslint-disable-next-line no-console
-        if (isErrMessages(error)) console.error(error[0]);
+        // if (error instanceof ApiError) console.error(error.message);
       } finally {
         setIsLoading(() => false);
       }

--- a/src/provider/UserAuthProvider.tsx
+++ b/src/provider/UserAuthProvider.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState, VFC } from 'react';
+
+import { refresh } from 'feature/api/users/refresh';
+import { useAppDispatch, setUserAuth } from 'store';
+import { isErrMessages } from 'feature/api';
+import { DataLoading } from 'components/atoms/DataLoading';
+
+type Type = {
+  children: JSX.Element;
+};
+
+export const UserAuthProvider: VFC<Type> = ({ children }) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { userAuth } = await refresh();
+        if (userAuth) {
+          dispatch(setUserAuth(userAuth));
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        if (isErrMessages(error)) console.error(error[0]);
+      } finally {
+        setIsLoading(() => false);
+      }
+    };
+    void load();
+  }, [dispatch]);
+
+  return (
+    <>
+      {isLoading ? (
+        <DataLoading text="ログイン情報確認中..." py={8} />
+      ) : (
+        children
+      )}
+    </>
+  );
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ export const store = configureStore({
     userAuth: userAuthSlice.reducer,
   },
 });
+export type StoreType = typeof store;
 
 export const { setUserAuth } = userAuthSlice.actions;
 


### PR DESCRIPTION
# What
サイレントリフレッシュ機能として以下内容を実施。
- ky(httpクライアント)の前処理に以下内容を追加。
  - Reduxに格納された認証情報を取得するための処理（関数）を追加。
  - アクセストークンの期限をチェックし、期限が過ぎれいればリフレッシュAPIを送信
  - 期限が過ぎていなければそのまま本APIを送信
- kyの事後処理に以下内容を追加。
  - アクセストークンの期限切れの場合、リフレッシュAPIを送信
  - リフレッシュが成功した場合、本APIを再送信
- 上記事前、事後APIのエラー処理を行うためのカスタムエラークラスを作成。
- エラー後のアクションとしてログアウト処理（キャッシュや認証情報の削除）の共通化。